### PR TITLE
feat: update username path to also accept maxPosts

### DIFF
--- a/InstagramPosts.js
+++ b/InstagramPosts.js
@@ -99,7 +99,8 @@ var InstagramPosts = function InstagramPosts(_ref) {
 
   _react.default.useEffect(function () {
     username ? (0, _Instagram.scrapingInstagramPosts)({
-      username: username
+      username: username,
+      maxPosts: maxPosts ? maxPosts : 12
     }).then(function (res) {
       return setIgPosts(res);
     }) : (0, _Instagram.scrapingInstagramHashtags)({


### PR DESCRIPTION
Currently, if using the `username` prop there is no way to limit the # of posts returned.

My change adds the `maxPosts` ternary operation to the username branch of the conditional.